### PR TITLE
feat(admin): Add listing stats and detailed reviews

### DIFF
--- a/src/com/campshare/dao/interfaces/ListingDAO.java
+++ b/src/com/campshare/dao/interfaces/ListingDAO.java
@@ -10,6 +10,8 @@ public interface ListingDAO {
 
   long countAllActive();
 
+  long countAllArchived();
+
   List<Listing> findAll();
 
   List<Listing> findRecent(int limit);

--- a/src/com/campshare/dto/ListingsPageStatsDTO.java
+++ b/src/com/campshare/dto/ListingsPageStatsDTO.java
@@ -1,0 +1,49 @@
+package com.campshare.dto;
+
+public class ListingsPageStatsDTO {
+  private long total;
+  private long active;
+  private long archived;
+  private double activePercentage;
+  private double archivedPercentage;
+
+  public long getTotal() {
+    return total;
+  }
+
+  public long getActive() {
+    return active;
+  }
+
+  public long getArchived() {
+    return archived;
+  }
+
+  public double getActivePercentage() {
+    return activePercentage;
+  }
+
+  public double getArchivedPercentage() {
+    return archivedPercentage;
+  }
+
+  public void setTotal(long total) {
+    this.total = total;
+  }
+
+  public void setActive(long active) {
+    this.active = active;
+  }
+
+  public void setArchived(long archived) {
+    this.archived = archived;
+  }
+
+  public void setActivePercentage(double activePercentage) {
+    this.activePercentage = activePercentage;
+  }
+
+  public void setArchivedPercentage(double archivedPercentage) {
+    this.archivedPercentage = archivedPercentage;
+  }
+}

--- a/src/com/campshare/service/ListingService.java
+++ b/src/com/campshare/service/ListingService.java
@@ -2,6 +2,7 @@ package com.campshare.service;
 
 import com.campshare.dao.impl.ListingDAOImpl;
 import com.campshare.dao.interfaces.ListingDAO;
+import com.campshare.dto.ListingsPageStatsDTO;
 import com.campshare.model.Listing;
 import java.util.List;
 
@@ -26,5 +27,27 @@ public class ListingService {
 
   public boolean deleteListing(long listingId) {
     return listingDAO.delete(listingId);
+  }
+
+  public ListingsPageStatsDTO getListingPageStats() {
+    ListingsPageStatsDTO stats = new ListingsPageStatsDTO();
+
+    long total = listingDAO.countAll();
+    long active = listingDAO.countAllActive();
+    long archived = listingDAO.countAllArchived();
+
+    stats.setTotal(total);
+    stats.setActive(active);
+    stats.setArchived(archived);
+
+    if (total > 0) {
+      stats.setActivePercentage(((double) active / total) * 100.0);
+      stats.setArchivedPercentage(((double) archived / total) * 100.0);
+    } else {
+      stats.setActivePercentage(0.0);
+      stats.setArchivedPercentage(0.0);
+    }
+
+    return stats;
   }
 }

--- a/src/com/campshare/servlet/AdminListingsServlet.java
+++ b/src/com/campshare/servlet/AdminListingsServlet.java
@@ -1,6 +1,7 @@
 package com.campshare.servlet;
 
 import com.campshare.dto.AdminDashboardStatsDTO;
+import com.campshare.dto.ListingsPageStatsDTO;
 import com.campshare.model.Listing;
 import com.campshare.service.AdminDashboardService;
 import com.campshare.service.ListingService;
@@ -23,6 +24,8 @@ public class AdminListingsServlet extends HttpServlet {
 
     List<Listing> listings = listingService.getAllListings();
     request.setAttribute("listings", listings);
+    ListingsPageStatsDTO pageStats = listingService.getListingPageStats();
+    request.setAttribute("pageStats", pageStats); 
     request.getRequestDispatcher("/jsp/admin/listings.jsp").forward(request, response);
   }
 }

--- a/webapp/jsp/admin/listing_details.jsp
+++ b/webapp/jsp/admin/listing_details.jsp
@@ -171,7 +171,6 @@
                         
                         <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
                             
-                            <%-- Colonne de gauche pour la description --%>
                             <div class="md:col-span-2">
                                 <h4 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-2">Description de l'équipement</h4>
                                 <div class="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
@@ -231,7 +230,106 @@
                         </div>
                     </div>
 
-                </div>
+                        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 mb-6">
+                            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
+                                <i class="fas fa-star-half-alt mr-2 text-gray-500 dark:text-gray-400"></i> Évaluation Moyenne
+                            </h2>
+                            <c:set var="reviews" value="${listingDetails.item.reviews}"/>
+                            <c:set var="totalRating" value="0"/>
+                            <c:set var="reviewCount" value="${fn:length(reviews)}"/>
+
+                            <c:forEach var="review" items="${reviews}">
+                                <c:set var="totalRating" value="${totalRating + review.rating}"/>
+                            </c:forEach>
+
+                            <c:set var="averageRating" value="0"/>
+                            <c:if test="${reviewCount > 0}">
+                                <c:set var="averageRating" value="${totalRating / reviewCount}"/>
+                            </c:if>
+
+                            <div class="flex items-center space-x-2">
+                                <div class="flex text-yellow-400">
+                                    <c:forEach begin="1" end="5" var="i">
+                                        <c:choose>
+                                            <c:when test="${averageRating >= i}">
+                                                <i class="fas fa-star"></i>
+                                            </c:when>
+                                            <c:when test="${averageRating >= (i - 0.5)}">
+                                                <i class="fas fa-star-half-alt"></i> 
+                                            </c:when>
+                                            <c:otherwise>
+                                                <i class="far fa-star"></i> 
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </c:forEach>
+                                </div>
+                                <span class="text-gray-600 dark:text-gray-400 text-sm">
+                                    (<fmt:formatNumber value="${averageRating}" maxFractionDigits="1"/> sur 5) - <c:out value="${reviewCount}"/> avis
+                                </span>
+                            </div>
+                        </div>
+
+
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 mb-6">
+                            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
+                                <i class="fas fa-comments mr-2 text-gray-500 dark:text-gray-400"></i> Avis des Clients (<c:out value="${reviewCount}"/>)
+                            </h2>
+                            <div class="space-y-6 max-h-96 overflow-y-auto pr-2"> 
+
+                            
+                                <c:choose>
+                                    <c:when test="${reviewCount > 0}">
+                                        <c:forEach var="review" items="${reviews}">
+                                            <div class="pb-4 border-b border-gray-200 dark:border-gray-700 last:border-b-0">
+                                                <div class="flex items-center justify-between mb-1">
+                                                
+                                                <c:if test="${not empty review.reviewer}">
+                                                    <div class="flex items-center mb-2">
+                                                        <c:choose>
+                                                            <c:when test="${not empty fn:trim(review.reviewer.avatarUrl)}">
+                                                                <img class="h-8 w-8 rounded-full object-cover mr-3" src="${pageContext.request.contextPath}/uploads/${review.reviewer.avatarUrl}" alt="Avatar">
+                                                            </c:when>
+                                                            <c:otherwise>
+                                                                <img class="h-8 w-8 rounded-full object-cover mr-3" src="${pageContext.request.contextPath}/assets/images/default-avatar.png" alt="Avatar par défaut">
+                                                            </c:otherwise>
+                                                        </c:choose>
+                                                        <div>
+                                                            <button 
+                                                                type="button" 
+                                                                onclick="showUserDetails(${review.reviewer.id})" 
+                                                                class="text-sm font-semibold text-gray-900 dark:text-white hover:text-admin-secondary dark:hover:text-admin-accent transition-colors">
+                                                                <c:out value="${review.reviewer.firstName} ${review.reviewer.lastName}"/>
+                                                            </button>
+                                                            <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                                <fmt:formatDate value="${review.createdAt}" pattern="dd MMM yyyy"/>
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                </c:if>
+                                                    <div class="flex text-yellow-400 text-sm">
+                                                        <c:forEach begin="1" end="5" var="i">
+                                                            <i class="${i <= review.rating ? 'fas' : 'far'} fa-star"></i>
+                                                        </c:forEach>
+                                                    </div>
+                                                    
+                                                </div>
+                                                <p class="text-gray-700 dark:text-gray-300 text-sm">
+                                                    <c:out value="${review.comment}"/>
+                                                </p>
+                                                
+                                            </div>
+                                        </c:forEach>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <p class="text-gray-500 dark:text-gray-400 text-sm">Aucun avis n'a encore été laissé pour cet équipement.</p>
+                                    </c:otherwise>
+                                </c:choose>
+                            </div>
+                        </div>
+
+                    </div>
+
+                
 
                 <div class="space-y-6">
                     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">

--- a/webapp/jsp/admin/listings.jsp
+++ b/webapp/jsp/admin/listings.jsp
@@ -135,17 +135,16 @@ pageEncoding="UTF-8"%>
 
                     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6">
                         <div class="flex items-center">
-                            <div class="p-3 rounded-full bg-red-100 dark:bg-red-900/30 mr-4">
-                                <i class="fas fa-x text-red-600 dark:text-red-400"></i>
+                            <div class="p-3 rounded-full bg-yellow-100 dark:bg-yellow-900/30 mr-4">
+                                <i class="fas fa-archive text-yellow-600 dark:text-yellow-400"></i>
                             </div>
                             <div>
-                                <p class="text-gray-500 dark:text-gray-400 text-sm">Annonces Inactifs</p>
+                                <p class="text-gray-500 dark:text-gray-400 text-sm">Annonces Archivées</p>
                                 <div class="flex items-center">
-                                    <h3 class="text-2xl font-bold text-gray-900 dark:text-white"><c:out value="${pageStats.inactive}"/></h3>
-                                    
+                                    <h3 class="text-2xl font-bold text-gray-900 dark:text-white"><c:out value="${pageStats.archived}"/></h3>
                                 </div>
                                 <p class="text-gray-600 dark:text-gray-400 text-xs mt-1">
-                                    (<fmt:formatNumber value="${pageStats.inactivePercentage}" maxFractionDigits="0"/>% du total)
+                                    (<fmt:formatNumber value="${pageStats.archivedPercentage}" maxFractionDigits="0"/>% du total)
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
Implements two features for the admin panel:

1.  **Listing Page:**
    * Adds statistics cards (Total, Active, Archived) with percentages.
    * Uses `ListingsPageStatsDTO` and new DAO/Service methods for calculation.

2.  **Listing Details Page:**
    * Adds an average rating section with star display ⭐️.
    * Adds a customer review list, filtering for 'forObject' types.
    * Loads reviewer's `User` object (avatar, name) for each review.
    * Makes reviewer names clickable, triggering the user details modal.